### PR TITLE
feat: カード新データ受信時に折りたたみを自動展開する（Issue #33）

### DIFF
--- a/src/SidecarPanel.ts
+++ b/src/SidecarPanel.ts
@@ -430,6 +430,9 @@ export class SidecarPanel implements vscode.WebviewViewProvider {
             addSection('エラー原因の候補', summary.errorCauses, 'result-cause');
             addSection('次にやること', summary.nextActions, 'result-action');
 
+            resultCard.classList.remove('collapsed');
+            const resultIcon = resultCard.querySelector('.collapse-icon');
+            if (resultIcon) { resultIcon.textContent = '▼'; }
             resultCard.classList.add('visible');
         }
 
@@ -451,6 +454,9 @@ export class SidecarPanel implements vscode.WebviewViewProvider {
                 div.textContent = w;
                 cardWarnings.appendChild(div);
             });
+            card.classList.remove('collapsed');
+            const cardIcon = card.querySelector('.collapse-icon');
+            if (cardIcon) { cardIcon.textContent = '▼'; }
             card.classList.add('visible');
         }
 


### PR DESCRIPTION
## Summary
- `showCommandCard()` 呼び出し時にコマンド解説カードの `collapsed` クラスを除去して自動展開
- `showResultCard()` 呼び出し時に実行結果カードの `collapsed` クラスを除去して自動展開
- 自動展開時に collapse-icon を `▼` にリセット

Closes #33

## Test plan
- [ ] カードを折りたたんだ状態でコマンドを実行 → コマンド解説カードが自動展開されること
- [ ] 折りたたんだ状態で実行結果カードに新データが来ると自動展開されること
- [ ] 自動展開後の collapse-icon が ▼ になっていること
- [ ] 再度折りたたんで次のコマンドを実行 → 再び自動展開されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)