### PR TITLE
fix: node-pty PTY 起動失敗を修正し、プロファイルセッションを廃止して PTY に一本化する

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,6 +8,7 @@ src/**
 **/*.map
 **/*.ts
 node_modules/**
+!node_modules/node-pty/**
 out/test/**
 .claude/**
 os_docs/**

--- a/package.json
+++ b/package.json
@@ -27,11 +27,7 @@
         "command": "shirouto-code.openPanel",
         "title": "シロートコード: パネルを開く"
       },
-      {
-        "command": "shirouto-code.startSession",
-        "title": "シロートコード: 翻訳セッションを開始"
-      },
-      {
+{
         "command": "shirouto-code.startPtySession",
         "title": "シロートコード: PTY 翻訳セッションを起動"
       },
@@ -69,15 +65,7 @@
         }
       ]
     },
-    "terminal": {
-      "profiles": [
-        {
-          "title": "シロートコード翻訳セッション",
-          "id": "shirouto-code.translationSession"
-        }
-      ]
-    },
-    "configuration": {
+"configuration": {
       "title": "シロートコード",
       "properties": {
         "shirouto-code.geminiApiKey": {
@@ -87,7 +75,7 @@
         },
         "shirouto-code.geminiModel": {
           "type": "string",
-          "default": "gemini-2.0-flash",
+          "default": "gemini-2.0-flash-lite",
           "description": "使用する Gemini モデル名（コマンドパレット: 「シロートコード: AI モデルを選択」で最新モデル一覧から選択できます）"
         },
         "shirouto-code.customDangerCommands": {

--- a/src/GeminiClient.ts
+++ b/src/GeminiClient.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
-const DEFAULT_MODEL = 'gemini-2.0-flash';
+const DEFAULT_MODEL = 'gemini-2.0-flash-lite';
 
 /** API キー未設定エラーをこのセッションで既に通知済みかどうか */
 let apiKeyErrorShown = false;

--- a/src/SidecarPanel.ts
+++ b/src/SidecarPanel.ts
@@ -5,8 +5,6 @@ import type { ResultSummary } from './ResultSummarizer';
 import type { TranslationPair } from './Translator';
 
 export interface CapabilityState {
-    terminalData: 'available' | 'unavailable';
-    shellIntegration: 'available' | 'unavailable';
     aiSend: 'available' | 'no-key' | 'disabled';
 }
 
@@ -51,8 +49,8 @@ export class SidecarPanel implements vscode.WebviewViewProvider {
     }
 
     /** ターミナルセッション状態をパネルに反映する。name が null のときは切断状態 */
-    public updateSession(name: string | null, sessionType?: 'profile' | 'pty'): void {
-        this._view?.webview.postMessage({ type: 'sessionUpdate', name, sessionType });
+    public updateSession(name: string | null): void {
+        this._view?.webview.postMessage({ type: 'sessionUpdate', name });
     }
 
     /** パース済み出力行をパネルに追記する */
@@ -844,16 +842,9 @@ export class SidecarPanel implements vscode.WebviewViewProvider {
                 qaInput.focus();
             } else if (msg.type === 'capabilityUpdate') {
                 const { state } = msg;
-                // ターミナルキャプチャ状態
-                const terminalOk = state.terminalData === 'available' || state.shellIntegration === 'available';
-                if (terminalOk) {
-                    capTerminalDot.className = 'cap-dot ok';
-                    const method = state.terminalData === 'available' ? 'PTY モード' : 'Shell Integration';
-                    capTerminalLabel.textContent = 'ターミナルキャプチャ: 有効（' + method + '）';
-                } else {
-                    capTerminalDot.className = 'cap-dot na';
-                    capTerminalLabel.textContent = 'ターミナルキャプチャ: 無効 — --enable-proposed-api a2m-m.shirouto-code で起動 / コマンド解説・Q&A は利用可能';
-                }
+                // ターミナルキャプチャは PTY モード固定
+                capTerminalDot.className = 'cap-dot ok';
+                capTerminalLabel.textContent = 'ターミナルキャプチャ: 有効（PTY モード）';
                 // AI 機能状態
                 if (state.aiSend === 'available') {
                     capAiDot.className = 'cap-dot ok';

--- a/src/TranslationPseudoterminal.ts
+++ b/src/TranslationPseudoterminal.ts
@@ -1,28 +1,41 @@
 import * as vscode from 'vscode';
 import * as pty from 'node-pty';
 import { ZshHookInjector } from './ZshHookInjector';
+import { TerminalOutputParser, parseMarker, type ParsedLine } from './TerminalOutputParser';
 
 /**
  * Pseudoterminal ベースの翻訳セッション。
  * node-pty で実際の zsh プロセスを起動し、I/O をブリッジする。
  * コマンド境界検知は ZshHookInjector が注入した preexec/precmd フックのマーカーで行う。
+ * onDidWriteTerminalData に依存せず、node-pty の onData で直接処理する。
  */
 export class TranslationPseudoterminal implements vscode.Pseudoterminal {
     private readonly _writeEmitter = new vscode.EventEmitter<string>();
     private readonly _closeEmitter = new vscode.EventEmitter<number | void>();
+    private readonly _commandStartEmitter = new vscode.EventEmitter<string>();
+    private readonly _commandEndEmitter = new vscode.EventEmitter<number | undefined>();
+    private readonly _outputEmitter = new vscode.EventEmitter<ParsedLine[]>();
 
     readonly onDidWrite: vscode.Event<string> = this._writeEmitter.event;
     readonly onDidClose: vscode.Event<number | void> = this._closeEmitter.event;
+    /** コマンド開始時に発火（コマンド文字列を渡す） */
+    readonly onCommandStart: vscode.Event<string> = this._commandStartEmitter.event;
+    /** コマンド終了時に発火（終了コードを渡す） */
+    readonly onCommandEnd: vscode.Event<number | undefined> = this._commandEndEmitter.event;
+    /** パース済み出力行が生成されたときに発火 */
+    readonly onParsedOutput: vscode.Event<ParsedLine[]> = this._outputEmitter.event;
 
     private _pty: pty.IPty | undefined;
     private readonly _injector = new ZshHookInjector();
+    private readonly _parser = new TerminalOutputParser();
 
     open(initialDimensions: vscode.TerminalDimensions | undefined): void {
         const cols = initialDimensions?.columns ?? 80;
         const rows = initialDimensions?.rows ?? 24;
 
         try {
-            this._pty = pty.spawn('zsh', ['--interactive'], {
+            const shell = process.env.SHELL ?? '/bin/zsh';
+            this._pty = pty.spawn(shell, ['--interactive'], {
                 name: 'xterm-256color',
                 cols,
                 rows,
@@ -34,19 +47,51 @@ export class TranslationPseudoterminal implements vscode.Pseudoterminal {
             });
 
             this._pty.onData((data) => {
+                // VS Code ターミナルへ表示用データを送る
                 this._writeEmitter.fire(data);
+
+                // マーカーを先にチェックしてコマンド境界を検知
+                const marker = parseMarker(data);
+                if (marker?.type === 'start') {
+                    this._parser.notifyCommandStart();
+                    this._commandStartEmitter.fire(marker.command?.trim() ?? '');
+                } else if (marker?.type === 'end') {
+                    this._parser.notifyCommandEnd(marker.exitCode);
+                    const flushed = this._parser.flush();
+                    if (flushed.length > 0) {
+                        this._outputEmitter.fire(flushed);
+                    }
+                    this._commandEndEmitter.fire(marker.exitCode);
+                }
+
+                // 通常の出力行を処理（マーカーは ANSI_RE で除去される）
+                const lines = this._parser.push(data);
+                if (lines.length > 0) {
+                    this._outputEmitter.fire(lines);
+                }
             });
 
             this._pty.onExit(({ exitCode }) => {
                 this._closeEmitter.fire(exitCode);
             });
         } catch (err) {
-            // node-pty が利用できない場合（ネイティブビルド未実施等）はフォールバックメッセージを表示
-            const msg = err instanceof Error ? err.message : String(err);
+            const e = err as NodeJS.ErrnoException;
+            const msg = `${e.message} (code=${e.code ?? '?'} errno=${e.errno ?? '?'})`;
+            const shell = process.env.SHELL ?? '(undefined)';
+            // child_process でスポーンできるか診断
+            let cpTest = 'untested';
+            try {
+                const { spawnSync } = require('child_process') as typeof import('child_process');
+                const r = spawnSync('/bin/zsh', ['--version'], { timeout: 2000 });
+                cpTest = r.error ? `error: ${r.error.message}` : `ok: ${String(r.stdout).trim()}`;
+            } catch (e2) {
+                cpTest = `exception: ${e2}`;
+            }
             this._writeEmitter.fire(
                 'シロートコード: PTY セッションを起動できませんでした\r\n' +
-                `エラー: ${msg}\r\n` +
-                'npm run rebuild を実行してから拡張を再起動してください。\r\n'
+                `SHELL=${shell}\r\n` +
+                `node-pty エラー: ${msg}\r\n` +
+                `child_process テスト: ${cpTest}\r\n`
             );
         }
     }
@@ -74,5 +119,8 @@ export class TranslationPseudoterminal implements vscode.Pseudoterminal {
         this._injector.dispose();
         this._writeEmitter.dispose();
         this._closeEmitter.dispose();
+        this._commandStartEmitter.dispose();
+        this._commandEndEmitter.dispose();
+        this._outputEmitter.dispose();
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
-import { SidecarPanel, type CapabilityState } from './SidecarPanel';
-import { TerminalOutputParser } from './TerminalOutputParser';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SidecarPanel } from './SidecarPanel';
 import { TranslationPseudoterminal } from './TranslationPseudoterminal';
 import { explain, type CustomDangerRule } from './CommandExplainer';
 import { summarize } from './ResultSummarizer';
@@ -10,36 +11,37 @@ import { HistoryStore } from './HistoryStore';
 import { QuestionHandler, geminiErrorToMessage } from './QuestionHandler';
 import { GeminiClient } from './GeminiClient';
 import type { ParsedLine } from './TerminalOutputParser';
-import { parseMarker } from './TerminalOutputParser';
 
-const TRANSLATION_SESSION_NAME = 'シロートコード翻訳セッション';
 const PTY_SESSION_NAME = 'シロートコード PTY セッション';
 
 export function activate(context: vscode.ExtensionContext): void {
-    const out = vscode.window.createOutputChannel('シロートコード');
-    out.appendLine('[activate] 拡張機能が起動しました');
-    context.subscriptions.push(out);
-    vscode.window.showInformationMessage('シロートコード: 起動しました ✓');
+    // VSIX (ZIP) はファイルパーミッションを保持しないため、
+    // node-pty の spawn-helper に実行権限を付与する（macOS のみ必要）
+    if (process.platform === 'darwin') {
+        try {
+            const spawnHelper = path.join(
+                context.extensionPath,
+                'node_modules', 'node-pty', 'prebuilds',
+                `${process.platform}-${process.arch}`,
+                'spawn-helper'
+            );
+            if (fs.existsSync(spawnHelper)) {
+                fs.chmodSync(spawnHelper, 0o755);
+            }
+        } catch (_) { /* 権限付与失敗は無視 */ }
+    }
 
     const provider = new SidecarPanel(context.extensionUri);
-    const parser = new TerminalOutputParser();
     const historyStore = new HistoryStore(context.globalStorageUri);
     historyStore.load();
     historyStore.purgeExpired();
     const translator = new Translator();
     const questionHandler = new QuestionHandler();
-    let managedTerminalProfile: vscode.Terminal | undefined;
     let managedPtyTerminal: vscode.Terminal | undefined;
     let activePty: TranslationPseudoterminal | undefined;
+    let ptySubscriptions: vscode.Disposable[] = [];
     let currentCommandLines: ParsedLine[] = [];
     let lastCommandLines: ParsedLine[] = [];
-
-    // VS Code フォークではイベント間でターミナルオブジェクト参照が変わることがあるため
-    // 参照比較に加えて名前でフォールバック比較する
-    const isManagedTerminal = (t: vscode.Terminal): boolean =>
-        t === managedTerminalProfile ||
-        (managedTerminalProfile !== undefined && t.name === managedTerminalProfile.name) ||
-        t === managedPtyTerminal;
 
     // Q&A: ユーザーの質問を Gemini に送信して回答を表示
     provider.onQuestion = (text: string) => {
@@ -70,7 +72,7 @@ export function activate(context: vscode.ExtensionContext): void {
             provider.showAiAnswer(answer, contextSnippet);
             historyStore.save({
                 id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
-                sessionId: (managedTerminalProfile ?? managedPtyTerminal)?.name ?? 'unknown',
+                sessionId: managedPtyTerminal?.name ?? 'unknown',
                 timestamp: Date.now(),
                 question: text,
                 answer
@@ -109,7 +111,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 );
                 return;
             }
-            const currentModel = config.get<string>('geminiModel', 'gemini-2.0-flash');
+            const currentModel = config.get<string>('geminiModel', 'gemini-2.0-flash-lite');
             await vscode.window.withProgress(
                 { location: vscode.ProgressLocation.Notification, title: 'モデル一覧を取得中...', cancellable: false },
                 async () => {
@@ -139,21 +141,6 @@ export function activate(context: vscode.ExtensionContext): void {
         })
     );
 
-    // 翻訳セッション起動コマンドの登録（コマンドパレット・sidecar ボタン共用）
-    context.subscriptions.push(
-        vscode.commands.registerCommand('shirouto-code.startSession', () => {
-            if (managedTerminalProfile) {
-                managedTerminalProfile.show();
-                return;
-            }
-            const terminal = vscode.window.createTerminal({ name: TRANSLATION_SESSION_NAME });
-            managedTerminalProfile = terminal;
-            terminal.show();
-        })
-    );
-
-    provider.onStartSession = () => vscode.commands.executeCommand('shirouto-code.startSession');
-
     // PTY 翻訳セッション起動コマンドの登録
     context.subscriptions.push(
         vscode.commands.registerCommand('shirouto-code.startPtySession', () => {
@@ -163,50 +150,63 @@ export function activate(context: vscode.ExtensionContext): void {
                 return;
             }
             activePty = new TranslationPseudoterminal();
+
+            // PTY 内部イベントを購読
+            ptySubscriptions = [
+                activePty.onCommandStart((command) => {
+                    currentCommandLines = [];
+                    if (command.trim()) {
+                        const customRules = vscode.workspace
+                            .getConfiguration('shirouto-code')
+                            .get<CustomDangerRule[]>('customDangerCommands', []);
+                        provider.showCommandCard(explain(command, customRules));
+                    }
+                }),
+                activePty.onParsedOutput((lines) => {
+                    currentCommandLines.push(...lines);
+                    provider.appendOutput(lines);
+                }),
+                activePty.onCommandEnd((exitCode) => {
+                    provider.notifyCommandEnd(exitCode);
+                    const summary = summarize(currentCommandLines, exitCode);
+                    provider.showResultCard(summary);
+
+                    const config = vscode.workspace.getConfiguration('shirouto-code');
+                    const enableAiSend = config.get<boolean>('enableAiSend', true);
+                    if (enableAiSend) {
+                        const outputText = currentCommandLines.map(l => l.text).join('\n');
+                        if (outputText.trim()) {
+                            const { masked, hasMasked } = SecretMasker.fromConfig().mask(outputText);
+                            if (hasMasked) { provider.showMaskNotice(); }
+                            translator.translateBatch(masked).then(pair => {
+                                provider.showTranslation(pair);
+                            }).catch(() => { /* 翻訳失敗は無視 */ });
+                        }
+                    }
+                    lastCommandLines = [...currentCommandLines];
+                    currentCommandLines = [];
+                }),
+            ];
+
             const terminal = vscode.window.createTerminal({
                 name: PTY_SESSION_NAME,
                 pty: activePty
             });
             managedPtyTerminal = terminal;
-            provider.updateSession(PTY_SESSION_NAME, 'pty');
+            provider.updateSession(PTY_SESSION_NAME);
             terminal.show();
         })
     );
 
-    // 翻訳セッション Terminal Profile の登録
-    context.subscriptions.push(
-        vscode.window.registerTerminalProfileProvider('shirouto-code.translationSession', {
-            provideTerminalProfile(
-                _token: vscode.CancellationToken
-            ): vscode.ProviderResult<vscode.TerminalProfile> {
-                return new vscode.TerminalProfile({ name: TRANSLATION_SESSION_NAME });
-            }
-        })
-    );
-
-    // 管理対象ターミナルの追跡（プロファイル選択時に起動したターミナルを 1対1 でバインド）
-    context.subscriptions.push(
-        vscode.window.onDidOpenTerminal((terminal) => {
-            if (terminal.name === TRANSLATION_SESSION_NAME) {
-                managedTerminalProfile = terminal;
-                provider.updateSession(terminal.name, 'profile');
-            }
-        })
-    );
+    provider.onStartSession = () => vscode.commands.executeCommand('shirouto-code.startPtySession');
 
     context.subscriptions.push(
         vscode.window.onDidChangeActiveTerminal((terminal) => {
-            if (!terminal) {
+            if (!terminal || !managedPtyTerminal) {
                 return;
             }
-            if (!managedTerminalProfile && !managedPtyTerminal) {
-                return;
-            }
-            if (terminal === managedTerminalProfile ||
-                (managedTerminalProfile !== undefined && terminal.name === managedTerminalProfile.name)) {
-                provider.updateSession(terminal.name, 'profile');
-            } else if (terminal === managedPtyTerminal) {
-                provider.updateSession(terminal.name, 'pty');
+            if (terminal === managedPtyTerminal) {
+                provider.updateSession(terminal.name);
             } else {
                 provider.updateSession(null);
             }
@@ -215,34 +215,23 @@ export function activate(context: vscode.ExtensionContext): void {
 
     context.subscriptions.push(
         vscode.window.onDidCloseTerminal((terminal) => {
-            if (terminal === managedTerminalProfile ||
-                (managedTerminalProfile !== undefined && terminal.name === managedTerminalProfile.name)) {
-                managedTerminalProfile = undefined;
-                provider.updateSession(null);
-            }
             if (terminal === managedPtyTerminal) {
                 managedPtyTerminal = undefined;
                 activePty?.dispose();
                 activePty = undefined;
+                for (const sub of ptySubscriptions) { sub.dispose(); }
+                ptySubscriptions = [];
                 provider.updateSession(null);
             }
         })
     );
-
-    // ターミナル出力取得（proposed API: terminalDataWriteEvent）
-    // VS Code 起動時に --enable-proposed-api a2m-m.shirouto-code が必要
-    const win = vscode.window as unknown as {
-        onDidWriteTerminalData?: (
-            listener: (e: { terminal: vscode.Terminal; data: string }) => void
-        ) => vscode.Disposable;
-    };
 
     /** capability 状態を算出して sidecar に通知する */
     function notifyCapability(): void {
         const config = vscode.workspace.getConfiguration('shirouto-code');
         const enableAiSend = config.get<boolean>('enableAiSend', true);
         const geminiApiKey = config.get<string>('geminiApiKey', '');
-        let aiSend: CapabilityState['aiSend'];
+        let aiSend: 'available' | 'no-key' | 'disabled';
         if (!enableAiSend) {
             aiSend = 'disabled';
         } else if (!geminiApiKey || geminiApiKey.trim() === '') {
@@ -250,11 +239,7 @@ export function activate(context: vscode.ExtensionContext): void {
         } else {
             aiSend = 'available';
         }
-        provider.updateCapability({
-            terminalData: typeof win.onDidWriteTerminalData === 'function' ? 'available' : 'unavailable',
-            shellIntegration: typeof vscode.window.onDidStartTerminalShellExecution === 'function' ? 'available' : 'unavailable',
-            aiSend,
-        });
+        provider.updateCapability({ aiSend });
     }
 
     notifyCapability();
@@ -267,139 +252,6 @@ export function activate(context: vscode.ExtensionContext): void {
             }
         })
     );
-
-    if (typeof win.onDidWriteTerminalData === 'function') {
-        out.appendLine('[terminalData] API 利用可能');
-        context.subscriptions.push(
-            win.onDidWriteTerminalData((event) => {
-                const managed = isManagedTerminal(event.terminal);
-                out.appendLine(`[terminalData] fired terminal="${event.terminal.name}" managed=${managed}`);
-                if (managed) {
-                    vscode.window.showInformationMessage(`シロートコード: terminalData 受信 managed=${managed}`);
-                }
-                if (!managed) {
-                    return;
-                }
-
-                // PTY セッション時: ZshHookInjector が埋め込んだマーカーでコマンド境界を検知
-                // Shell Integration イベントが発火しない環境でも動作するためのフォールバック
-                if (activePty !== undefined) {
-                    const marker = parseMarker(event.data);
-                    if (marker?.type === 'start') {
-                        currentCommandLines = [];
-                        parser.notifyCommandStart();
-                        if (marker.command?.trim()) {
-                            const customRules = vscode.workspace
-                                .getConfiguration('shirouto-code')
-                                .get<CustomDangerRule[]>('customDangerCommands', []);
-                            provider.showCommandCard(explain(marker.command.trim(), customRules));
-                        }
-                    } else if (marker?.type === 'end') {
-                        const boundary = parser.notifyCommandEnd(marker.exitCode);
-                        if (boundary.type === 'end') {
-                            provider.notifyCommandEnd(boundary.exitCode);
-                        }
-                        const flushed = parser.flush();
-                        if (flushed.length > 0) {
-                            currentCommandLines.push(...flushed);
-                            provider.appendOutput(flushed);
-                        }
-                        const summary = summarize(currentCommandLines, marker.exitCode);
-                        provider.showResultCard(summary);
-
-                        const config = vscode.workspace.getConfiguration('shirouto-code');
-                        const enableAiSend = config.get<boolean>('enableAiSend', true);
-                        if (enableAiSend) {
-                            const outputText = currentCommandLines.map(l => l.text).join('\n');
-                            if (outputText.trim()) {
-                                const { masked, hasMasked } = SecretMasker.fromConfig().mask(outputText);
-                                if (hasMasked) {
-                                    provider.showMaskNotice();
-                                }
-                                translator.translateBatch(masked).then(pair => {
-                                    provider.showTranslation(pair);
-                                }).catch(() => { /* 翻訳失敗は無視 */ });
-                            }
-                        }
-                        lastCommandLines = [...currentCommandLines];
-                        currentCommandLines = [];
-                    }
-                }
-
-                // マーカーは ANSI_RE によって除去されるため、通常行の処理は常に実行する
-                const lines = parser.push(event.data);
-                if (lines.length > 0) {
-                    currentCommandLines.push(...lines);
-                    provider.appendOutput(lines);
-                }
-            })
-        );
-    }
-
-    // コマンド境界検出（VS Code 1.90+: shell integration events）
-    if (typeof vscode.window.onDidStartTerminalShellExecution === 'function') {
-        out.appendLine('[shellIntegration] API 利用可能');
-        context.subscriptions.push(
-            vscode.window.onDidStartTerminalShellExecution((e) => {
-                const managed = isManagedTerminal(e.terminal);
-                out.appendLine(`[shellIntegration] fired terminal="${e.terminal.name}" managed=${managed}`);
-                vscode.window.showInformationMessage(`シロートコード: shellExec 受信 managed=${managed}`);
-                if (!managed) {
-                    return;
-                }
-                currentCommandLines = [];
-                parser.notifyCommandStart();
-                // コマンド解説カードを sidecar に表示
-                const cmdLine = e.execution?.commandLine?.value;
-                if (typeof cmdLine === 'string' && cmdLine.trim()) {
-                    const customRules = vscode.workspace
-                        .getConfiguration('shirouto-code')
-                        .get<CustomDangerRule[]>('customDangerCommands', []);
-                    provider.showCommandCard(explain(cmdLine, customRules));
-                }
-            })
-        );
-    }
-    if (typeof vscode.window.onDidEndTerminalShellExecution === 'function') {
-        context.subscriptions.push(
-            vscode.window.onDidEndTerminalShellExecution((e) => {
-                if (!isManagedTerminal(e.terminal)) {
-                    return;
-                }
-                const boundary = parser.notifyCommandEnd(e.exitCode);
-                if (boundary.type === 'end') {
-                    provider.notifyCommandEnd(boundary.exitCode);
-                }
-                const flushed = parser.flush();
-                if (flushed.length > 0) {
-                    currentCommandLines.push(...flushed);
-                    provider.appendOutput(flushed);
-                }
-                // 実行後要約カードを表示
-                const summary = summarize(currentCommandLines, e.exitCode);
-                provider.showResultCard(summary);
-
-                // コマンド出力を翻訳して sidecar に渡す（AI 送信前に秘密情報をマスキング）
-                const config = vscode.workspace.getConfiguration('shirouto-code');
-                const enableAiSend = config.get<boolean>('enableAiSend', true);
-                if (enableAiSend) {
-                    const outputText = currentCommandLines.map(l => l.text).join('\n');
-                    if (outputText.trim()) {
-                        const { masked, hasMasked } = SecretMasker.fromConfig().mask(outputText);
-                        if (hasMasked) {
-                            provider.showMaskNotice();
-                        }
-                        translator.translateBatch(masked).then(pair => {
-                            provider.showTranslation(pair);
-                        }).catch(() => { /* 翻訳失敗は無視 */ });
-                    }
-                }
-
-                lastCommandLines = [...currentCommandLines];
-                currentCommandLines = [];
-            })
-        );
-    }
 }
 
 export function deactivate(): void {


### PR DESCRIPTION
## Summary

- **spawn-helper 実行権限問題を修正**: VSIX (ZIP) はファイルパーミッションを保持しないため `spawn-helper` の `+x` が失われ `posix_spawnp failed` になっていた。`activate()` 冒頭で `chmod 755` を適用することで解消
- **node-pty を VSIX に同梱**: `.vscodeignore` に `!node_modules/node-pty/**` を追加
- **プロファイルセッションを廃止**: `onDidWriteTerminalData`（proposed API 必須）・Shell Integration イベントに依存したプロファイルセッションを削除し、PTY セッション一本に統一
- **TranslationPseudoterminal を刷新**: 内部でマーカー検知・出力パースを完結させ、`onCommandStart` / `onCommandEnd` / `onParsedOutput` イベントを公開。extension.ts は proposed API に依存しない
- **Gemini デフォルトモデル変更**: `gemini-2.0-flash` → `gemini-2.0-flash-lite`（旧モデルが新規ユーザーに非提供）

Closes #59

## Test plan

- [ ] VSIX を再インストール後、「シロートコード: PTY 翻訳セッションを起動」でターミナルが開く
- [ ] コマンドを実行するとサイドカーパネルにコマンドカード・出力・要約が表示される
- [ ] Gemini API キーを設定して翻訳・Q&A が動作する
- [ ] ターミナルを閉じると接続状態が切断に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)